### PR TITLE
build: generate checksums for build files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ deploy:
   file:
     - output/*.tar.gz
     - output/*.zip
+    - output/*.sha1
+    - output/*.sha256
+    - output/*.sha512
   file_glob: true
   skip_cleanup: true
   on:

--- a/build.sh
+++ b/build.sh
@@ -23,11 +23,26 @@ base="$(pwd)"
 output_name="fomu-toolchain-${ARCH}-${TRAVIS_TAG}"
 output="${base}/output/${output_name}"
 input="${base}/input"
+
 mkdir -p $output
 mkdir -p $input
 mkdir -p $output/bin
 
 echo "${TRAVIS_TAG}" > $output/VERSION
+
+checksum_output() {
+    set +x
+    hashes="sha1 sha256 sha512"
+    local outfile hashfile
+    outfile=$output$1
+
+    for hash in $hashes ; do
+	hashfile=$outfile.$hash
+        ${hash}sum $outfile > $hashfile
+	echo -n "$hash: " ; cat $hashfile
+    done
+    set -x
+}
 
 case "${ARCH}" in
     "windows")
@@ -76,6 +91,7 @@ case "${ARCH}" in
 
         cd $base/output
         zip -r $output_name.zip $output_name
+        checksum_output .zip
         ;;
 
     "macos")
@@ -108,6 +124,7 @@ case "${ARCH}" in
 
         cd $base/output
         zip -r $output_name.zip $output_name
+        checksum_output .zip
         ;;
 
     "linux_x86_64")
@@ -140,6 +157,7 @@ case "${ARCH}" in
 
         cd $base/output
         tar cvzf $output_name.tar.gz $output_name
+        checksum_output .tar.gz
         ;;
     *)
         echo "Unrecognized architecture: ${ARCH}"


### PR DESCRIPTION
SHA1, SHA256, and SHA512 checksums are now generated (and uploaded to
releases) for toolchains on all arches. This will allow checksums of
artifacts to be verified as coming from CI. This is particularly useful
during Fomu workshops where the toolchain is distributed on USB drives
to work around local bandwidth limitations.

`set +x` is used to clean up the output by disabling the echo of
commands while checksum calculation is performed and enabled again with
`set -x` once checksums calcs are complete.