### PR TITLE
merge v1.5.6 into master

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,22 +1,22 @@
 #!/bin/sh -x
 set -e
 
-win_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.44-fomu/nextpnr-ice40-windows_amd64-v1.44-fomu.zip"
-win_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.39-fomu/toolchain-icestorm-windows_amd64-v1.39-fomu.zip"
-win_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.9/wishbone-tool-v0.6.9-x86_64-pc-windows-gnu.tar.gz"
+win_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-windows_amd64-v1.46-fomu.zip"
+win_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-windows_amd64-v1.43-fomu.zip"
+win_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-pc-windows-gnu.tar.gz"
 win_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-w64-mingw32.zip"
 win_python_url="https://www.python.org/ftp/python/3.7.3/python-3.7.3-embed-amd64.zip"
 win_make_url="https://sourceforge.net/projects/ezwinports/files/make-4.3-without-guile-w32-bin.zip/download"
 win_teraterm_url="https://osdn.net/frs/redir.php?m=constant&f=ttssh2%2F71232%2Fteraterm-4.103.zip"
 
-mac_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.44-fomu/nextpnr-ice40-darwin-v1.44-fomu.tar.gz"
-mac_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.39-fomu/toolchain-icestorm-darwin-v1.39-fomu.tar.gz"
-mac_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.9/wishbone-tool-v0.6.9-x86_64-apple-darwin.tar.gz"
+mac_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-darwin-v1.46-fomu.tar.gz"
+mac_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-darwin-v1.43-fomu.tar.gz"
+mac_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-apple-darwin.tar.gz"
 mac_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-apple-darwin.tar.gz"
 
-linux_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.44-fomu/nextpnr-ice40-linux_x86_64-v1.44-fomu.tar.gz"
-linux_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.39-fomu/toolchain-icestorm-linux_x86_64-v1.39-fomu.tar.gz"
-linux_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.9/wishbone-tool-v0.6.9-x86_64-unknown-linux-gnu.tar.gz"
+linux_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-linux_x86_64-v1.46-fomu.tar.gz"
+linux_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-linux_x86_64-v1.43-fomu.tar.gz"
+linux_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-unknown-linux-gnu.tar.gz"
 linux_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz"
 
 base="$(pwd)"


### PR DESCRIPTION
In seems that #11 and v1.5.6 were based on v1.5.5, but only #11 was merged into master. Hence, version updates from v1.5.6 are currently not merged into master. This PR fixes it.