### PR TITLE
migrate from xobs/toolchain-* to open-tool-forge/fpga-toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
 # Fomu Toolchain
 
-Fomu is an FPGA in your USB port.  This repository contains prebuilt versions of all the tools you will need to develop for Fomu.
+[Fomu](https://github.com/im-tomu/fomu-hardware) ([fomu.im](https://fomu.im)) is an FPGA in your USB port.  This repository gathers all the tools you will need to develop for Fomu, and provides them as prebuilt packages for GNU/Linux, Windows or macOS.
 
 ## Usage
 
 Download the [latest release](https://github.com/im-tomu/fomu-toolchain/releases/latest) for your platform and extract it somewhere on your disk.  Then set your PATH:
 
-* MacOS: `export PATH=[path-to-bin]:$PATH`
-* Linux: `export PATH=[path-to-bin]:$PATH`
-* Windows Powershell: `$ENV:PATH = "[path-to-bin];" + $ENV:PATH`
-* Windows cmd.exe: `PATH=[path-to-bin];%PATH%`
+* Shell (GNU/Linux, Cygwin/MSYS2/MINGW, MacOS...): `export PATH=[path-to-bin]:$PATH`
+* Powershell (Windows): `$ENV:PATH = "[path-to-bin];" + $ENV:PATH`
+* cmd.exe (Windows): `PATH=[path-to-bin];%PATH%`
 
 To confirm installation, run a command such as `nextpnr-ice40` or `yosys`.
 
 ## What's included
 
-This contains _almost_ everything you'll need to develop on Fomu:
+Prebuilt packages contain _almost_ everything you'll need for developing software and/or hardware on Fomu:
 
-* **yosys** -- synthesis
-* **nextpnr-ice40** -- place-and-route
-* **dfu-util** -- upload bitstream to the FPGA
-* **python3** -- required for `nextpnr-ice40` and to build litex projects
-* **riscv-gcc** -- compile code for RISC-V CPUs, such as the Fomu softcore
-* **wishbone-tool** -- access the debug bus on Fomu
+* [open-tool-forge/fpga-toolchain](https://github.com/open-tool-forge/fpga-toolchain):
+  * **yosys** -- synthesis
+  * **ghdl-yosys-plugin** -- VHDL frontend for Yosys
+  * **nextpnr** -- place-and-route
+  * **dfu-util** -- upload bitstream to the FPGA
+  * **python3** -- required for `nextpnr-ice40` and for building litex projects
+  * Find the list of all tools at [open-tool-forge/fpga-toolchain: Introduction](https://github.com/open-tool-forge/fpga-toolchain#introduction).
+* Extras, specific for Fomu:
+  * **riscv-gcc** -- compile code for RISC-V CPUs, such as the Fomu softcore
+  * **wishbone-tool** -- access the debug bus on Fomu
+  * The Windows version includes `make` and `teraterm`.
 
-Additionally, the macOS and Windows versions include `make`.
-
-It is strongly recommended that you install `git` to manage repositories and check out code, though it is not strictly necessary.
+It is strongly recommended that you install `git` for managing repositories and checking out code, though it is not strictly necessary.

--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ Prebuilt packages contain _almost_ everything you'll need for developing softwar
 
 * [open-tool-forge/fpga-toolchain](https://github.com/open-tool-forge/fpga-toolchain):
   * **yosys** -- synthesis
-  * **ghdl-yosys-plugin** -- VHDL frontend for Yosys
+  * **ghdl-yosys-plugin** -- VHDL frontend for *Yosys*
   * **nextpnr** -- place-and-route
   * **dfu-util** -- upload bitstream to the FPGA
-  * **python3** -- required for `nextpnr-ice40` and for building litex projects
   * Find the list of all tools at [open-tool-forge/fpga-toolchain: Introduction](https://github.com/open-tool-forge/fpga-toolchain#introduction).
 * Extras, specific for Fomu:
   * **riscv-gcc** -- compile code for RISC-V CPUs, such as the Fomu softcore
   * **wishbone-tool** -- access the debug bus on Fomu
   * The Windows version includes `make` and `teraterm`.
+
+NOTE: *fpga-toolchain* includes an internal *lib/python3.8* interpreter to be used by *nextpnr*. However, users should install a Python interpreter on their system for using *LiteX* or other Python based hardware description/design tools.
 
 It is strongly recommended that you install `git` for managing repositories and checking out code, though it is not strictly necessary.

--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,17 @@
 #!/bin/sh -x
 set -e
 
-win_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-windows_amd64-v1.46-fomu.zip"
-win_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-windows_amd64-v1.43-fomu.zip"
+win_openfpgatoolchain_url="https://github.com/open-tool-forge/fpga-toolchain/releases/download/nightly-20201010/fpga-toolchain-windows_amd64-nightly-20201010.zip"
 win_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-pc-windows-gnu.tar.gz"
 win_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-w64-mingw32.zip"
-win_python_url="https://www.python.org/ftp/python/3.7.3/python-3.7.3-embed-amd64.zip"
 win_make_url="https://sourceforge.net/projects/ezwinports/files/make-4.3-without-guile-w32-bin.zip/download"
 win_teraterm_url="https://osdn.net/frs/redir.php?m=constant&f=ttssh2%2F71232%2Fteraterm-4.103.zip"
 
-mac_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-darwin-v1.46-fomu.tar.gz"
-mac_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-darwin-v1.43-fomu.tar.gz"
+mac_openfpgatoolchain_url="https://github.com/open-tool-forge/fpga-toolchain/releases/download/nightly-20201010/fpga-toolchain-darwin-nightly-20201010.tar.xz"
 mac_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-apple-darwin.tar.gz"
 mac_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-apple-darwin.tar.gz"
 
-linux_nextpnr_url="https://github.com/xobs/toolchain-nextpnr-ice40/releases/download/v1.46-fomu/nextpnr-ice40-linux_x86_64-v1.46-fomu.tar.gz"
-linux_yosys_url="https://github.com/xobs/toolchain-icestorm/releases/download/v1.43-fomu/toolchain-icestorm-linux_x86_64-v1.43-fomu.tar.gz"
+linux_openfpgatoolchain_url="https://github.com/open-tool-forge/fpga-toolchain/releases/download/nightly-20201010/fpga-toolchain-linux_x86_64-nightly-20201010.tar.xz"
 linux_wishbone_tool_url="https://github.com/litex-hub/wishbone-utils/releases/download/v0.6.10/wishbone-tool-v0.6.10-x86_64-unknown-linux-gnu.tar.gz"
 linux_riscv_url="https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-centos6.tar.gz"
 
@@ -51,16 +47,10 @@ extract_zip() {
 
 case "${ARCH}" in
     "Windows")
-        # Python 3.7.3 (which matches the version in nextpnr)
-        extract_zip $win_python_url $input/python-${ARCH}.zip  "/bin"
-        rm python37.zip # we already have this unzipped from nextpnr-ice40
-        rm -f python37._pth # If this file is present, PYTHONPATH is very broken
-
-        # Nextpnr
-        extract_zip $win_nextpnr_url $input/nextpnr-${ARCH}.zip "/bin"
-
-        # Yosys, icestorm, and dfu_util
-        extract_zip $win_yosys_url $input/yosys-${ARCH}.zip
+        # Open FPGA toolchain
+        wget -O $input/openfpgatoolchain-${ARCH}.zip $win_openfpgatoolchain_url
+        unzip $input/openfpgatoolchain-${ARCH}.zip
+        mv fpga-toolchain/* $output/
 
         # Teraterm Terminal
         extract_zip $win_teraterm_url $input/teraterm-${ARCH}.zip "/bin"
@@ -91,11 +81,9 @@ case "${ARCH}" in
         ;;
 
     "macOS")
-        # Nextpnr
-        curl -fsSL $mac_nextpnr_url | tar xvzf - -C $output
-
-        # Yosys, icestorm, and dfu_util
-        curl -fsSL $mac_yosys_url | tar xvzf - -C $output
+        # Open FPGA toolchain
+        curl -fsSL $mac_openfpgatoolchain_url | tar xvJf - -C $input
+        mv $input/fpga-toolchain/* $output/
 
         # Wishbone Tool
         curl -fsSL $mac_wishbone_tool_url | tar xvzf - -C $output/bin
@@ -118,11 +106,9 @@ case "${ARCH}" in
         ;;
 
     "Linux")
-        # Nextpnr
-        curl -fsSL $linux_nextpnr_url | tar xvzf - -C $output
-
-        # Yosys, icestorm, and dfu_util
-        curl -fsSL $linux_yosys_url | tar xvzf - -C $output
+        # Open FPGA toolchain
+        curl -fsSL $linux_openfpgatoolchain_url | tar xvJf - -C $input
+        mv $input/fpga-toolchain/* $output/
 
         # Wishbone Tool
         curl -fsSL $linux_wishbone_tool_url | tar xvzf - -C $output/bin
@@ -130,7 +116,7 @@ case "${ARCH}" in
         # Riscv Toolchain
         # Note that we want to strip the front part of the path.
         # Also, we do "cp -l" then "rm -rf" to merge the directories.
-        wget -O $input/riscv-${ARCH}.tar.gz  $linux_riscv_url
+        wget -O $input/riscv-${ARCH}.tar.gz $linux_riscv_url
         cd $input
         mkdir re
         cd re


### PR DESCRIPTION
Close #18
Close #19

NOTE: this PR is based on #19, which is based on #18.

This enhancement was discussed in: #16, im-tomu/fomu-workshop#319, im-tomu/fomu-workshop#334

Resources from `xobs/toolchain-*` repos are replaced with releases from [open-tool-forge/fpga-toolchain](https://github.com/open-tool-forge/fpga-toolchain). That is, the following tools are no longer explicitly included:

- yosys
- nextpnr-ice40
- dfu-util
- python3

At the same time, fpga-toolchain includes multiple additional tools which are not available in the current Fomu toolchain:

- GHDL Yosys Plugin
- GHDL
- SymbiYosys
- ecpprog
- etc.

The addition of ghdl-yosys-plugin is specially relevant because it provides built-in support for synthesising either VHDL or mixed-language designs, instead of requiring Docker as in im-tomu/fomu-workshop#334.

---

Since this PR is based on #19, these changes are tested in CI, ensuring that the tests from the workshop can be successfully executed on all three platforms. At the same time, artifacts are available for anyone to try: https://github.com/umarcor/fomu-toolchain/actions/runs/299916520. Feedback is very welcome.