### PR TITLE
Dockerfile use installer

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+      - Dockerfile-use-installer
+  pull_request:
+    branches:
+      - master
+      - Dockerfile-use-installer
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: fomu-toolchain
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build ./dockerfiles --file dockerfiles/Dockerfile.use-installer --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+  
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+  
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+  
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+  
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+  
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+  
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+  
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile.use-installer
+++ b/Dockerfile.use-installer
@@ -1,0 +1,42 @@
+ARG IMAGE="python:3-slim-buster"
+
+#---
+# Place anything that is common to both the build and execution environment in base 
+#
+FROM $IMAGE AS base
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    ca-certificates \
+    git \
+    make \
+    wget \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists
+
+RUN wget https://github.com/im-tomu/fomu-toolchain/releases/download/v1.5.6/fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
+    tar -xvf fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
+    rm fomu-toolchain-linux_x86_64-v1.5.6.tar.gz
+
+ENV PATH=/fomu-toolchain-linux_x86_64-v1.5.6/bin:$PATH
+
+FROM base as release-candidate
+
+RUN adduser --disabled-password fomu
+USER fomu
+WORKDIR /home/fomu
+
+# Commented section to show where we would run tests in an image layer identical to the release candidate
+# without polluting the release candidate with test results.  Uncomment the following and add tests:
+# FROM release-candidate as test-release-candidate
+# Ideally we would run some tests here 
+
+FROM release-candidate as fomu-toolchain
+
+# Below are some sample commands to build and run a docker images.
+# 
+# docker build -f Dockerfile.use-installer . -t fomu-toolchain
+#
+# docker run -it -v $(pwd):/home/fomu fomu-toolchain bash
+

--- a/Dockerfile.use-installer
+++ b/Dockerfile.use-installer
@@ -9,6 +9,7 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     ca-certificates \
     git \
+    libusb-1.0-0 \
     make \
     wget \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
@@ -23,9 +24,13 @@ ENV PATH=/fomu-toolchain-linux_x86_64-v1.5.6/bin:$PATH
 
 FROM base as release-candidate
 
-RUN adduser --disabled-password fomu
-USER fomu
-WORKDIR /home/fomu
+ENV USER=fomu
+RUN adduser --disabled-password ${USER}
+
+RUN usermod -a -G plugdev ${USER}
+# COPY 99-fomu.rules /etc/udev/rules.d/99-fomu.rules
+USER ${USER}
+WORKDIR /home/${USER}
 
 # Commented section to show where we would run tests in an image layer identical to the release candidate
 # without polluting the release candidate with test results.  Uncomment the following and add tests:
@@ -39,4 +44,8 @@ FROM release-candidate as fomu-toolchain
 # docker build -f Dockerfile.use-installer . -t fomu-toolchain
 #
 # docker run -it -v $(pwd):/home/fomu fomu-toolchain bash
-
+#
+# The --privileged param may be used to allow access to usb devices
+# but it allows access to much more, and may be a security risk.
+# There may be a better way to allow dfu-util to run 
+# docker run -it -v $(pwd):/home/fomu --privileged fomu-toolchain bash

--- a/dockerfiles/99-fomu.rules
+++ b/dockerfiles/99-fomu.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="5bf0", MODE="0664", GROUP="plugdev"

--- a/dockerfiles/Dockerfile.use-installer
+++ b/dockerfiles/Dockerfile.use-installer
@@ -16,26 +16,40 @@ RUN apt-get update -qq \
  && update-ca-certificates \
  && rm -rf /var/lib/apt/lists
 
+# FROM base as builder 
+# Install necessary tools and source code and build from source here for ci/cd
+# If any build or test return a non-zero exit code, the docker build stops
+# with an error, which is nice for ci/cd like github actions.
+
+# FROM builder as test-builder
+# Run regression tests on binaries built from source here
+
+# FROM builder as installer
+# create an installer from the binaries built from source here
+
+FROM base as release-candidate
+# use --copy-from builder to copy binaries into the right place here if built from source, 
+# or copy the installer with --copy-from installer 
+# or use the pre-built released installer as we do here:
 RUN wget https://github.com/im-tomu/fomu-toolchain/releases/download/v1.5.6/fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
     tar -xvf fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
     rm fomu-toolchain-linux_x86_64-v1.5.6.tar.gz
-
+ 
 ENV PATH=/fomu-toolchain-linux_x86_64-v1.5.6/bin:$PATH
-
-FROM base as release-candidate
 
 ENV USER=fomu
 RUN adduser --disabled-password ${USER}
-
+# RUN groupadd plugdev # error - already exists
 RUN usermod -a -G plugdev ${USER}
-# COPY 99-fomu.rules /etc/udev/rules.d/99-fomu.rules
+COPY 99-fomu.rules /etc/udev/rules.d/99-fomu.rules
+# RUN udevadm control --reload-rules
+# RUN udevadm trigger
 USER ${USER}
 WORKDIR /home/${USER}
 
-# Commented section to show where we would run tests in an image layer identical to the release candidate
-# without polluting the release candidate with test results.  Uncomment the following and add tests:
 # FROM release-candidate as test-release-candidate
-# Ideally we would run some tests here 
+# Run any tests on final image here 
+
 
 FROM release-candidate as fomu-toolchain
 
@@ -47,5 +61,11 @@ FROM release-candidate as fomu-toolchain
 #
 # The --privileged param may be used to allow access to usb devices
 # but it allows access to much more, and may be a security risk.
-# There may be a better way to allow dfu-util to run 
+# There may be a better way to allow dfu-util and wishbone-tool to run 
 # docker run -it -v $(pwd):/home/fomu --privileged fomu-toolchain bash
+# 
+# On my old laptop running ubuntu 20.04, I need to re-run the docker 
+# container after using dfu-util in order to use it again or to use
+# wishbone-tool.  Perhaps I am missing a dependency here?  I installed
+# udev and dfu-util above just to see if that would pull in something
+# I missed, but I don't think it helped.  I removed them again.

--- a/dockerfiles/Dockerfile.use-installer
+++ b/dockerfiles/Dockerfile.use-installer
@@ -25,11 +25,12 @@ RUN apt-get update -qq \
 # Run regression tests on binaries built from source here
 
 # FROM builder as installer
-# create an installer from the binaries built from source here
+# use COPY --from=builder to get the binaries from builder stage and
+# create an installer from those binaries built from source here
 
 FROM base as release-candidate
-# use --copy-from builder to copy binaries into the right place here if built from source, 
-# or copy the installer with --copy-from installer 
+# use COPY --from=builder to copy binaries into the right place here if built from source, 
+# or copy the installer with COPY --from=installer 
 # or use the pre-built released installer as we do here:
 RUN wget https://github.com/im-tomu/fomu-toolchain/releases/download/v1.5.6/fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
     tar -xvf fomu-toolchain-linux_x86_64-v1.5.6.tar.gz && \
@@ -54,8 +55,12 @@ WORKDIR /home/${USER}
 FROM release-candidate as fomu-toolchain
 
 # Below are some sample commands to build and run a docker images.
+# Execute the docker build commands from within the dockerfiles folder.
 # 
 # docker build -f Dockerfile.use-installer . -t fomu-toolchain
+#
+# Execute the docker run commands from the fomu-workshop folder
+# or from your own project's folder as appropriate.
 #
 # docker run -it -v $(pwd):/home/fomu fomu-toolchain bash
 #


### PR DESCRIPTION
Added Dockerfile.use-installer to a dockerfiles directory.  This may be used to build a container image with binaries from the latest installer.  Also added a github actions workflow to automatically build and publish a docker container package to github, so it may be pulled by anyone without having to run a docker build.  The build tools (yosys, riscv compiler, etc) all work when this container is run on the platforms I was able to test it on including Win 10 with WSL2, Ubuntu 20.04, and Chromebook running Linux Beta.