### PR TITLE
ci: add scheduled runs and workflow_dispatch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,6 +3,9 @@ name: 'update'
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
CI in this repo did not run in 6 months, because no updates were pushed. This PR enables scheduled (weekly) runs, along with allowing manually triggering workflows through the GUI or the API.