### PR TITLE
ci: bump zig to 0.8.0

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -82,14 +82,14 @@ jobs:
       if: matrix.os == 'ubuntu'
       run: |
         tar xzf ${{ env.FOMU_TOOLCHAIN }}.tar.gz
-        curl -L https://ziglang.org/download/0.6.0/zig-linux-x86_64-0.6.0.tar.xz | tar -xJf -
-        echo "$(pwd)/zig-linux-x86_64-0.6.0" >> $GITHUB_PATH
+        curl -L https://ziglang.org/download/0.8.0/zig-linux-x86_64-0.8.0.tar.xz | tar -xJf -
+        echo "$(pwd)/zig-linux-x86_64-0.8.0" >> $GITHUB_PATH
 
     - name: Install (Windows)
       if: matrix.os == 'windows'
       run: |
         unzip ${{ env.FOMU_TOOLCHAIN }}.zip
-        choco install zig --version 0.6.0
+        choco install zig --version 0.8.0
         ln -s $(which python) /usr/bin/python3
 
     - name: Install (Mac OS)


### PR DESCRIPTION
Close #27.

This PR bumps the version of zig installed in CI (from 0.6.0 to 0.8.0), in order to fix the current failing test jobs.