### PR TITLE
ci: eine/tip was merged into pyTooling/Actions/releaser

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -117,7 +117,7 @@ jobs:
 
     - uses: actions/download-artifact@v2
 
-    - uses: eine/tip@master
+    - uses: pyTooling/Actions/releaser@r0
       with:
         token: ${{ github.token }}
         tag: nightly


### PR DESCRIPTION
Same codebase. It was just moved from one repo to another.